### PR TITLE
Add vim-airline back

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ The theme will change to match the theme option specified.
 
 Note: The included theme is called `material_vim` because lightline.vim comes with its own version of a material theme (which does not change based on the theme version selected).
 
+### vim-airline
+
+To use the included [vim-airline](https://github.com/vim-airline/vim-airline) theme:
+
+```vim
+:AirlineTheme material
+
+# or
+let g:airline_theme = 'material'
+```
+
 ### Terminal Color Scheme
 
 Corresponding terminal color schemes are included in this repo. You can find them [here](https://github.com/kaicataldo/material.vim/tree/master/terminal-colors/).

--- a/autoload/airline/themes/material.vim
+++ b/autoload/airline/themes/material.vim
@@ -1,0 +1,42 @@
+let g:airline#themes#material#palette = {}
+
+function! airline#themes#material#refresh()
+  let g:airline#themes#material#palette.accents = {
+    \ 'red': airline#themes#get_highlight('Identifier'),
+    \ }
+
+  let s:N1 = airline#themes#get_highlight2(['CursorLine', 'bg'], ['Directory', 'fg'], 'bold')
+  let s:N2 = airline#themes#get_highlight('Pmenu')
+  let s:N3 = airline#themes#get_highlight('TabLine')
+  let g:airline#themes#material#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
+
+  let group = airline#themes#get_highlight('Type')
+  let g:airline#themes#material#palette.normal_modified = {
+    \ 'airline_c': [ group[0], '', group[2], '', '' ]
+    \ }
+
+  let s:I1 = airline#themes#get_highlight2(['CursorLine', 'bg'], ['MoreMsg', 'fg'], 'bold')
+  let g:airline#themes#material#palette.insert = airline#themes#generate_color_map(s:I1, s:N2, s:N3)
+  let g:airline#themes#material#palette.insert_modified = g:airline#themes#material#palette.normal_modified
+
+  let s:R1 = airline#themes#get_highlight2(['CursorLine', 'bg'], ['Error', 'fg'], 'bold')
+  let g:airline#themes#material#palette.replace = airline#themes#generate_color_map(s:R1, s:N2, s:N3)
+  let g:airline#themes#material#palette.replace_modified = g:airline#themes#material#palette.normal_modified
+
+  let s:V1 = airline#themes#get_highlight2(['CursorLine', 'bg'], ['Statement', 'fg'], 'bold')
+  let g:airline#themes#material#palette.visual = airline#themes#generate_color_map(s:V1, s:N2, s:N3)
+  let g:airline#themes#material#palette.visual_modified = g:airline#themes#material#palette.normal_modified
+
+  let s:IA = airline#themes#get_highlight2(['NonText', 'fg'], ['CursorLine', 'bg'])
+  let g:airline#themes#material#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
+  let g:airline#themes#material#palette.inactive_modified = g:airline#themes#material#palette.normal_modified
+
+  if get(g:, 'loaded_ctrlp', 0)
+    let g:airline#themes#material#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(
+      \ airline#themes#get_highlight('CursorLine'),
+      \ airline#themes#get_highlight2(['Operator', 'fg'], ['Normal', 'bg']),
+      \ airline#themes#get_highlight2(['Normal', 'bg'], ['Operator', 'fg'], 'bold'))
+  endif
+endfun
+
+call airline#themes#material#refresh()


### PR DESCRIPTION
After updating my plugins today, airline stopped working. Noted a similar report in #26 and traced the change back to #21 (in edfed09). In the PR, you mentioned:

>  the current version is broken and I'm not using vim-airline at the moment

I don't agree. The material airline theme works great and I've had no issues so far (even if it might not look exactly like lightline's). I think it's better to wait for a PR from people who want it updated to resolve the issue instead of removing it outright and breaking vim configs for those who're happy with it.

Let me know what you think. Also, love the theme and thank you for porting it to vim!