### PR TITLE
Add initial MaxMEllon/vim-jsx-pretty styles

### DIFF
--- a/colors/material.vim
+++ b/colors/material.vim
@@ -267,6 +267,9 @@ call s:SetHighlight('jsTemplateExpression', s:red, '', '')
 call s:SetHighlight('jsThis', s:red, '', '')
 call s:SetHighlight('jsUndefined', s:orange, '', '')
 
+" MaxMEllon/vim-jsx-pretty
+call s:SetHighlight('jsxAttrib', s:yellow, '', 'italic')
+
 " JSON
 call s:SetHighlight('jsonBraces', s:fg, '', '')
 


### PR DESCRIPTION
This adds support for HTML attributes in JSX to display as italic. There may be other JSX changes to make as well, so this can be used as a starting point, or merged as is if you're interested. Thanks for an awesome theme!
<img width="279" alt="image" src="https://user-images.githubusercontent.com/82437/68714158-57277800-056d-11ea-94d0-0e9211f0c1fb.png">
