### PR TITLE
Fix NERDTree file highlight on hover

### DIFF
--- a/colors/material.vim
+++ b/colors/material.vim
@@ -386,6 +386,11 @@ hi link SignifySignDelete GitGutterDelete
 " vim-better-whitespace
 call s:SetHighlight('ExtraWhitespace', '', s:red, '')
 
+" NERDTree
+if has('nvim')
+  call s:SetHighlight('NERDTreeFile', s:fg, '', '')
+endif
+
 " Neovim terminal colors
 if has('nvim')
   let g:terminal_color_background = s:bg


### PR DESCRIPTION
A couple of things happen when a file in NERDTree is hovered:
  1 - the `ColumnLine` highlight is applied to it
  2 - the `NERDTreeFile` highlight is applied to it

NERDTree by default maps the `NERDTreeFile` highlight to the `Normal`
highlight set in a theme. Since `Normal` has been set to have a
particular foreground and background you would get an issue where the
`ColumnLine` highlight is applied (black background for the line) when
you hover a file in NERDTree, and then the `Normal` highlight is applied
which would overwrite the background of the file name text resulting in
a confusing highlight.

This commit adds dedicated colors to `NERDTreeFile` highlight, mainly
just sets the foreground so that the background can be set correctly
depending on the context.

Fixes #37 