### PR TITLE
check if g:material_colorscheme_map exists

### DIFF
--- a/autoload/airline/themes/material.vim
+++ b/autoload/airline/themes/material.vim
@@ -1,6 +1,10 @@
 let g:airline#themes#material#palette = {}
 
 function! airline#themes#material#refresh()
+  if ! exists('g:material_colorscheme_map')
+    return
+  endif
+
   let g:airline#themes#material#palette.accents = {
     \ 'red': [g:material_colorscheme_map.red, g:material_colorscheme_map.bg, '', ''],
     \ }


### PR DESCRIPTION
otherwise will fail when reinstalling the plugins in vim-plug