### PR TITLE
Rust inlay type hints

### DIFF
--- a/colors/material.vim
+++ b/colors/material.vim
@@ -425,6 +425,10 @@ call s:SetHighlight('rubyRegexp', s:cyan, '', '')
 call s:SetHighlight('rubyRegexpDelimiter', s:violet, '', '')
 call s:SetHighlight('rubyStringDelimiter', s:green, '', '')
 
+" Rust
+call s:SetHighlight('CocRustTypeHint', s:invisibles, '', '')
+call s:SetHighlight('CocRustChainingHint', s:invisibles, '', '')
+
 " TeX
 call s:SetHighlight('texBeginEndName', s:blue, '', '')
 call s:SetHighlight('texMathMatcher', s:blue, '', '')


### PR DESCRIPTION
The widely used `coc-rust-analyzer` language server plugin for Rust recently started supporting inlay type hints for variables and method chains. These currently use the default "type annotation" color scheme, which makes these hints visually overwhelming. I've found that assigning these to `invisibles` makes them more useful, and more closely matches the UI of other editors such as VSCode or Intellij.

I'm not sure if the change is too specific to be accepted, but I think anyone using this theme with Rust will appreciate it.

Current colors:
<img width="734" alt="old_color" src="https://user-images.githubusercontent.com/23020003/108785351-3a833980-753f-11eb-86e4-ada1a4d75ac1.png">

New colors:
<img width="765" alt="new_color" src="https://user-images.githubusercontent.com/23020003/108785367-42db7480-753f-11eb-8a78-74544c400e5a.png">