### PR TITLE
Add lualine material theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ To use the included [vim-airline](https://github.com/vim-airline/vim-airline) th
 let g:airline_theme = 'material'
 ```
 
+### lualine.nvim
+
+To use the included [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim) theme:
+```lua
+require('lualine').setup({
+  options = {
+    theme = require('material.lualine'),
+  },
+})
+```
+
+
 ### Terminal Color Scheme
 
 Corresponding terminal color schemes are included in this repo. You can find them [here](https://github.com/kaicataldo/material.vim/tree/master/terminal-colors/).

--- a/lua/material/lualine.lua
+++ b/lua/material/lualine.lua
@@ -5,7 +5,7 @@ local notify = vim.notify
 -- If material colors are not found, defaults to lualine material theme
 if not colors then
   local msg = 'material colors not loaded. Defaults to lualine material theme'
-  notify(msg, 'warn', { title = 'material.nvim' })
+  notify(msg, 'warn', { title = 'material.vim' })
   return require('lualine.themes.material')
 end
 

--- a/lua/material/lualine.lua
+++ b/lua/material/lualine.lua
@@ -1,0 +1,38 @@
+local colors = vim.g.material_colorscheme_map
+local style = vim.g.material_theme_style
+local notify = vim.notify
+
+-- If material colors are not found, defaults to lualine material theme
+if not colors then
+  local msg = 'material colors not loaded. Defaults to lualine material theme'
+  notify(msg, 'warn', { title = 'material.nvim' })
+  return require('lualine.themes.material')
+end
+
+local middle = style == 'lighter' and colors.fg or colors.selection
+local b_bg = colors.line_numbers
+
+return {
+  normal = {
+    a = { fg = colors.bg.gui, bg = colors.cyan.gui, gui = 'bold' },
+    b = { fg = colors.fg.gui, bg = b_bg.gui },
+    c = { fg = colors.fg.gui, bg = middle.gui },
+  },
+  insert = {
+    a = { fg = colors.bg.gui, bg = colors.purple.gui, gui = 'bold' },
+    b = { fg = colors.fg.gui, bg = b_bg.gui },
+  },
+  visual = {
+    a = { fg = colors.bg.gui, bg = colors.blue.gui, gui = 'bold' },
+    b = { fg = colors.fg.gui, bg = b_bg.gui },
+  },
+  replace = {
+    a = { fg = colors.bg.gui, bg = colors.green.gui, gui = 'bold' },
+    b = { fg = colors.fg.gui, bg = b_bg.gui },
+  },
+  inactive = {
+    a = { fg = colors.fg.gui, bg = colors.bg, gui = 'bold' },
+    b = { fg = colors.fg.gui, bg = b_bg.gui },
+    c = { fg = colors.fg.gui, bg = middle.gui },
+  },
+}


### PR DESCRIPTION
close #62 
I added a material theme for [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim).
It is very basic but provide a new theme to use with lualine.
I used colors used for lightline plugin as base.
