### PR TITLE
Fix diffNewFile link, add diffOldFile link

### DIFF
--- a/colors/material.vim
+++ b/colors/material.vim
@@ -222,7 +222,8 @@ call s:SetHighlight('Todo', s:orange, s:bg, 'italic')
 
 " Legacy groups for official git.vim and diff.vim syntax
 hi! link diffFile DiffAdd
-hi! link diffNewFile DiffDelete
+hi! link diffNewFile DiffAdd
+hi! link diffOldFile DiffDelete
 hi! link diffAdded DiffAdd
 hi! link diffChanged DiffChange
 hi! link diffLine DiffChange


### PR DESCRIPTION
Currently, `diffNewFile` links to `DiffDelete`, which is backwards, and `diffOldFile` isn't linked at all, leading to misleading display of filenames in diffs:

## Before
<img width="522" height="177" alt="image" src="https://github.com/user-attachments/assets/e6c9fcd5-4cae-4ea7-8e5c-fefe46b509d9" />

## After
<img width="522" height="177" alt="image" src="https://github.com/user-attachments/assets/210f9cd2-95f1-490a-882a-785e3bb9c2bd" />
